### PR TITLE
Update to *ring* 0.9.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,5 @@ homepage = "https://github.com/SpinResearch/lamport.rs"
 repository = "https://github.com/SpinResearch/lamport.rs"
 
 [dependencies]
-ring = "^0.6.0"
+ring = "^0.9.3"
 rand = "^0.3.0"
-


### PR DESCRIPTION
*ring* 0.9.3 is the first version that prevents multiple versions of
*ring* from being linked together. Soon *ring* 0.9.3 will be the oldest
version of *ring* on crates.io. *ring* 0.6.* have already been yanked.