### PR TITLE
Verify length of signature before indexing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,10 @@ impl PublicKey {
 
     /// Verifies that the signature of the data is correctly signed with the given key
     pub fn verify_signature(&self, signature: &LamportSignatureData, data: &[u8]) -> bool {
+        if signature.len() != self.algorithm.output_len * 8 {
+            return false;
+        }
+        
         let mut context = Context::new(self.algorithm);
         context.update(data);
         let result = context.finish();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -45,6 +45,25 @@ fn test_sign_verif() {
 }
 
 #[test]
+fn test_sign_verif_sig_wrong_size() {
+    let mut priv_key = PrivateKey::new(digest_512);
+    let data = "Hello World".as_bytes();
+    let mut too_short = priv_key.sign(data).unwrap();
+    let extra = too_short.pop();
+
+    let pub_key = priv_key.public_key();
+
+    assert!(!pub_key.verify_signature(&too_short, data));
+
+    let mut priv_key = PrivateKey::new(digest_512);
+    let data = "Hello World".as_bytes();
+    let mut too_long = priv_key.sign(data).unwrap();
+    too_long.extend(extra);
+
+    assert!(!pub_key.verify_signature(&too_long, data));
+}
+
+#[test]
 fn test_sign_verif_fail() {
     let mut priv_key = PrivateKey::new(digest_512);
     let data = "Hello Word".as_bytes();


### PR DESCRIPTION
If a `LamportSignatureData` object with too few subvectors was passed to the old
code, it would panic when `offset` grew bigger than the number of subvectors.
Obviously, panicing is much better behaviour than what we'd get in other
languages (thanks Rust), but still not ideal.